### PR TITLE
Add support for bitbucket in visit method

### DIFF
--- a/lib/vpr/git_parser.rb
+++ b/lib/vpr/git_parser.rb
@@ -31,5 +31,20 @@ module Vpr
       git = Git.open(Dir.pwd)
       git.current_branch
     end
+
+    def self.host
+      git = Git.open(Dir.pwd)
+
+      remotes = {}
+      git.remotes.each do |remote|
+        remotes[remote.name.to_sym] = remote.url
+      end
+
+      remote_uri = remotes[:origin]
+
+      matched = remote_uri.match(REGEXP)
+
+      matched[:host]
+    end
   end
 end

--- a/lib/vpr/url.rb
+++ b/lib/vpr/url.rb
@@ -27,7 +27,12 @@ module Vpr
     end
 
     def self.commit_url(commit)
-      "#{GitParser.repo_url}/commit/#{commit}"
+      path = {
+        'github.com': 'commit',
+        'bitbucket.org': 'commits'
+      }
+
+      "#{GitParser.repo_url}/#{path[GitParser.host.to_sym]}/#{commit}"
     end
 
     def self.search_url(commit)

--- a/spec/url_spec.rb
+++ b/spec/url_spec.rb
@@ -60,9 +60,20 @@ RSpec.describe Vpr::Url do
   describe '.commit_url' do
     subject { described_class.commit_url(commit) }
 
-    it 'returns the commit url' do
-      url = %r{https://github.com/\w+/vpr/commit/30bd60}
-      expect(subject).to match(url)
+    context 'when github' do
+      it 'returns the commit url' do
+        url = %r{https://github.com/\w+/vpr/commit/30bd60}
+        expect(subject).to match(url)
+      end
+    end
+
+    context 'when bitbucket' do
+      it 'returns the commit url' do
+        url = %r{https://bitbucket.org/\w+/vpr/commits/30bd60}
+        expect(Vpr::GitParser).to receive(:host).and_return('bitbucket.org')
+        expect(Vpr::GitParser).to receive(:repo_url).and_return('https://bitbucket.org/JuanCrg90/vpr')
+        expect(subject).to match(url)
+      end
     end
   end
 


### PR DESCRIPTION
Bitbucket uses `/commits/` as part of it URL instead on `/commit/`, this add
adds bitbucket support for `vpr visit` command