### PR TITLE
Add vpr --version command

### DIFF
--- a/lib/vpr/cli.rb
+++ b/lib/vpr/cli.rb
@@ -4,6 +4,8 @@ require 'vpr/url'
 
 module Vpr
   class CLI < Thor
+    map '--version' => :version
+
     desc 'home', 'visit the project page in github'
     def home
       Launchy.open(Url.home_url)
@@ -42,6 +44,11 @@ module Vpr
     desc 'search COMMIT', 'search the commit in github'
     def search(commit)
       Launchy.open(Url.search_url(commit))
+    end
+
+    desc 'version', 'show the gem version'
+    def version
+      Vpr::VERSION
     end
   end
 end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -65,4 +65,14 @@ RSpec.describe "CLI" do
       Vpr::CLI.start(["search", '123'])
     end
   end
+
+  describe 'version' do
+    it 'shows gem version with double dash' do
+      expect(Vpr::CLI.start(["--version"])).to match("1.0.0")
+    end
+
+    it 'shows gem version without double dash' do
+      expect(Vpr::CLI.start(["version"])).to match("1.0.0")
+    end
+  end
 end


### PR DESCRIPTION
Adds version command. 

Can be used with `--version` or `version`. Wasn't sure which would be better since the issue asked for `--version` but all other commands do not prefix `--`, so I included both. 😄 

Happy to remove one if requested. 

fixes #10