### PR TITLE
Support to select remote branch to visit

### DIFF
--- a/lib/vpr.rb
+++ b/lib/vpr.rb
@@ -1,5 +1,6 @@
 #:nodoc:
 module Vpr
+  autoload :Configuration, "vpr/configuration"
   autoload :GitParser, "vpr/git_parser"
   autoload :Url, "vpr/url"
   autoload :CLI, "vpr/cli"

--- a/lib/vpr/cli.rb
+++ b/lib/vpr/cli.rb
@@ -1,54 +1,70 @@
 require "thor"
 require "launchy"
 require "vpr/url"
+require "vpr/configuration"
 
 module Vpr
   class CLI < Thor
     map "--version" => :version
+    class_option :remote, default: "origin"
 
     desc "home", "visit the project page in github"
     def home
+      select_remote
       Launchy.open(Url.home_url)
     end
 
     desc "pulls", "visit the project pull requests page in github"
     def pulls
+      select_remote
       Launchy.open(Url.pulls_url)
     end
 
     desc "issues", "visit the project issues page in github"
     def issues
+      select_remote
       Launchy.open(Url.issues_url)
     end
 
     desc "branches", "visit the project branches page in github"
     def branches
+      select_remote
       Launchy.open(Url.branches_url)
     end
 
     desc "branch", "visit the current branch in github"
     def branch
+      select_remote
       Launchy.open(Url.branch_url)
     end
 
     desc "pull", "visit the pull request for the current branch (if exist) in github"
     def pull
+      select_remote
       Launchy.open(Url.pull_url)
     end
 
     desc "visit COMMIT", "visit the commit in github"
     def visit(commit)
+      select_remote
       Launchy.open(Url.commit_url(commit))
     end
 
     desc "search COMMIT", "search the commit in github"
     def search(commit)
+      select_remote
       Launchy.open(Url.search_url(commit))
     end
 
     desc "version", "show the gem version"
     def version
       Vpr::VERSION
+    end
+
+    private
+
+    def select_remote
+      Configuration.instance.remote = options[:remote].to_sym
     end
   end
 end

--- a/lib/vpr/configuration.rb
+++ b/lib/vpr/configuration.rb
@@ -1,0 +1,9 @@
+require "singleton"
+
+module Vpr
+  class Configuration
+    include Singleton
+
+    attr_accessor :remote
+  end
+end

--- a/lib/vpr/git_parser.rb
+++ b/lib/vpr/git_parser.rb
@@ -1,4 +1,5 @@
 require "git"
+require "vpr/configuration"
 
 module Vpr
   class GitParser
@@ -20,7 +21,7 @@ module Vpr
         remotes[remote.name.to_sym] = remote.url
       end
 
-      remote_uri = remotes[:origin]
+      remote_uri = remotes[Configuration.instance.remote]
 
       matched = remote_uri.match(REGEXP)
 
@@ -40,7 +41,7 @@ module Vpr
         remotes[remote.name.to_sym] = remote.url
       end
 
-      remote_uri = remotes[:origin]
+      remote_uri = remotes[Configuration.instance.remote]
 
       matched = remote_uri.match(REGEXP)
 

--- a/lib/vpr/git_parser.rb
+++ b/lib/vpr/git_parser.rb
@@ -13,39 +13,41 @@ module Vpr
     (?<repo>[^/.]+)
     }x.freeze
 
-    def self.repo_url
-      git = Git.open(Dir.pwd)
+    class << self
+      def repo_url
+        git = Git.open(Dir.pwd)
 
-      remotes = {}
-      git.remotes.each do |remote|
-        remotes[remote.name.to_sym] = remote.url
+        remotes = {}
+        git.remotes.each do |remote|
+          remotes[remote.name.to_sym] = remote.url
+        end
+
+        remote_uri = remotes[Configuration.instance.remote]
+
+        matched = remote_uri.match(REGEXP)
+
+        File.join("https://#{matched[:host]}", matched[:owner], matched[:repo])
       end
 
-      remote_uri = remotes[Configuration.instance.remote]
-
-      matched = remote_uri.match(REGEXP)
-
-      File.join("https://#{matched[:host]}", matched[:owner], matched[:repo])
-    end
-
-    def self.current_branch
-      git = Git.open(Dir.pwd)
-      git.current_branch
-    end
-
-    def self.host
-      git = Git.open(Dir.pwd)
-
-      remotes = {}
-      git.remotes.each do |remote|
-        remotes[remote.name.to_sym] = remote.url
+      def current_branch
+        git = Git.open(Dir.pwd)
+        git.current_branch
       end
 
-      remote_uri = remotes[Configuration.instance.remote]
+      def host
+        git = Git.open(Dir.pwd)
 
-      matched = remote_uri.match(REGEXP)
+        remotes = {}
+        git.remotes.each do |remote|
+          remotes[remote.name.to_sym] = remote.url
+        end
 
-      matched[:host]
+        remote_uri = remotes[Configuration.instance.remote]
+
+        matched = remote_uri.match(REGEXP)
+
+        matched[:host]
+      end
     end
   end
 end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -2,67 +2,205 @@ require "spec_helper"
 require "launchy"
 
 RSpec.describe "CLI" do
+  let(:configuration) { Vpr::Configuration.instance }
+
   describe "home" do
+    let(:url) { %r{https://github.com/\w+/vpr} }
+
     it "open github homepage" do
-      url = %r{https://github.com/\w+/vpr}
       expect(Launchy).to receive(:open).with(url)
       Vpr::CLI.start(["home"])
+    end
+
+    context "when user does not specify a remote" do
+      it "use :origin by default" do
+        expect(Launchy).to receive(:open).with(url)
+        expect(configuration).to receive(:remote).and_return(:origin)
+        Vpr::CLI.start(["home"])
+      end
+    end
+
+    context "when user specify a remote" do
+      it "open github remote's home page" do
+        expect(Launchy).to receive(:open).with(url)
+        expect(configuration).to receive(:remote).and_return(:mine)
+        Vpr::CLI.start(["home", "--remote", "mine"])
+      end
     end
   end
 
   describe "pulls" do
+    let(:url) { %r{https://github.com/\w+/vpr/pulls} }
+
     it "open github pull requests page" do
-      url = %r{https://github.com/\w+/vpr/pulls}
       expect(Launchy).to receive(:open).with(url)
       Vpr::CLI.start(["pulls"])
+    end
+
+    context "when user does not specify a remote" do
+      it "use :origin by default" do
+        expect(Launchy).to receive(:open).with(url)
+        expect(configuration).to receive(:remote).and_return(:origin)
+        Vpr::CLI.start(["pulls"])
+      end
+    end
+
+    context "when user specify a remote" do
+      it "open github remote's pull request" do
+        expect(Launchy).to receive(:open).with(url)
+        expect(configuration).to receive(:remote).and_return(:mine)
+        Vpr::CLI.start(["pulls", "--remote", "mine"])
+      end
     end
   end
 
   describe "issues" do
+    let(:url) { %r{https://github.com/\w+/vpr/issues} }
+
     it "open github issues page" do
-      url = %r{https://github.com/\w+/vpr/issues}
       expect(Launchy).to receive(:open).with(url)
       Vpr::CLI.start(["issues"])
+    end
+
+    context "when user does not specify a remote" do
+      it "use :origin by default" do
+        expect(Launchy).to receive(:open).with(url)
+        expect(configuration).to receive(:remote).and_return(:origin)
+        Vpr::CLI.start(["issues"])
+      end
+    end
+
+    context "when user specify a remote" do
+      it "open github remote's issues page" do
+        expect(Launchy).to receive(:open).with(url)
+        expect(configuration).to receive(:remote).and_return(:mine)
+        Vpr::CLI.start(["issues", "--remote", "mine"])
+      end
     end
   end
 
   describe "branches" do
+    let(:url) { %r{https://github.com/\w+/vpr/branches} }
+
     it "open github branches page" do
-      url = %r{https://github.com/\w+/vpr/branches}
       expect(Launchy).to receive(:open).with(url)
       Vpr::CLI.start(["branches"])
+    end
+
+    context "when user does not specify a remote" do
+      it "use :origin by default" do
+        expect(Launchy).to receive(:open).with(url)
+        expect(configuration).to receive(:remote).and_return(:origin)
+        Vpr::CLI.start(["branches"])
+      end
+    end
+
+    context "when user specify a remote" do
+      it "open githube remote's branches page" do
+        expect(Launchy).to receive(:open).with(url)
+        expect(configuration).to receive(:remote).and_return(:mine)
+        Vpr::CLI.start(["branches", "--remote", "mine"])
+      end
     end
   end
 
   describe "branch" do
+    let(:url) { %r{https://github.com/\w+/vpr/tree/\w+} }
+
     it "open github branch page" do
-      url = %r{https://github.com/\w+/vpr/tree/\w+}
       expect(Launchy).to receive(:open).with(url)
       Vpr::CLI.start(["branch"])
+    end
+
+    context "when user does not specify a remote" do
+      it "use :origin by default" do
+        expect(Launchy).to receive(:open).with(url)
+        expect(configuration).to receive(:remote).and_return(:origin)
+        Vpr::CLI.start(["branch"])
+      end
+    end
+
+    context "when user specify a remote" do
+      it "open github remote's branch page" do
+        expect(Launchy).to receive(:open).with(url)
+        expect(configuration).to receive(:remote).and_return(:mine)
+        Vpr::CLI.start(["branch", "--remote", "mine"])
+      end
     end
   end
 
   describe "pull" do
+    let(:url) { %r{https://github.com/\w+/vpr/pull/\w+} }
+
     it "open github current branch pull request page" do
-      url = %r{https://github.com/\w+/vpr/pull/\w+}
       expect(Launchy).to receive(:open).with(url)
       Vpr::CLI.start(["pull"])
+    end
+
+    context "when user does not specify a remote" do
+      it "use :origin by default" do
+        expect(Launchy).to receive(:open).with(url)
+        expect(configuration).to receive(:remote).and_return(:origin)
+        Vpr::CLI.start(["pull"])
+      end
+    end
+
+    context "when user specify a remote" do
+      it "open github remote's current branch pull request page" do
+        expect(Launchy).to receive(:open).with(url)
+        expect(configuration).to receive(:remote).and_return(:mine)
+        Vpr::CLI.start(["pull", "--remote", "mine"])
+      end
     end
   end
 
   describe "visit" do
+    let(:url) { %r{https://github.com/\w+/vpr/commit/123} }
+
     it "open initial commit github page" do
-      url = %r{https://github.com/\w+/vpr/commit/123}
       expect(Launchy).to receive(:open).with(url)
       Vpr::CLI.start(["visit", "123"])
+    end
+
+    context "when user does not specify a remote" do
+      it "use :origin by default" do
+        expect(Launchy).to receive(:open).with(url)
+        expect(configuration).to receive(:remote).twice.and_return(:origin)
+        Vpr::CLI.start(["visit", "123"])
+      end
+    end
+
+    context "when user specify a remote" do
+      it "open initial remote's commit github page" do
+        expect(Launchy).to receive(:open).with(url)
+        expect(configuration).to receive(:remote).twice.and_return(:mine)
+        Vpr::CLI.start(["visit", "123", "--remote", "mine"])
+      end
     end
   end
 
   describe "search" do
+    let(:url) { %r{https://github.com/\w+/vpr/search\?q=123} }
+
     it "open initial commit github search page" do
-      url = %r{https://github.com/\w+/vpr/search\?q=123}
       expect(Launchy).to receive(:open).with(url)
       Vpr::CLI.start(["search", "123"])
+    end
+
+    context "when user does not specify a remote" do
+      it "use :origin by default" do
+        expect(Launchy).to receive(:open).with(url)
+        expect(configuration).to receive(:remote).and_return(:origin)
+        Vpr::CLI.start(["search", "123"])
+      end
+    end
+
+    context "when user specify a remote" do
+      it "open initial remote's commit github search page" do
+        expect(Launchy).to receive(:open).with(url)
+        expect(configuration).to receive(:remote).and_return(:mine)
+        Vpr::CLI.start(["search", "123", "--remote", "mine"])
+      end
     end
   end
 


### PR DESCRIPTION
This permits to the user specify the remote repository that wants to
visit for next actions:
  - home
  - pulls
  - pull
  - issues
  - branches
  - branch
  - visit
  - search

![Oct-04-2019 09-17-51](https://user-images.githubusercontent.com/39539196/66214848-17c15e00-e688-11e9-9812-8c9a0e33d8b6.gif)

This solves: #8 