### PR TITLE
Fix test suite

### DIFF
--- a/lib/vpr/cli.rb
+++ b/lib/vpr/cli.rb
@@ -5,54 +5,51 @@ require "vpr/configuration"
 
 module Vpr
   class CLI < Thor
+    def initialize(args = [], local_options = {}, config = {})
+      super
+      select_remote
+    end
+
     map "--version" => :version
-    class_option :remote, default: "origin"
+    class_option :remote, default: :origin
 
     desc "home", "visit the project page in github"
     def home
-      select_remote
       Launchy.open(Url.home_url)
     end
 
     desc "pulls", "visit the project pull requests page in github"
     def pulls
-      select_remote
       Launchy.open(Url.pulls_url)
     end
 
     desc "issues", "visit the project issues page in github"
     def issues
-      select_remote
       Launchy.open(Url.issues_url)
     end
 
     desc "branches", "visit the project branches page in github"
     def branches
-      select_remote
       Launchy.open(Url.branches_url)
     end
 
     desc "branch", "visit the current branch in github"
     def branch
-      select_remote
       Launchy.open(Url.branch_url)
     end
 
     desc "pull", "visit the pull request for the current branch (if exist) in github"
     def pull
-      select_remote
       Launchy.open(Url.pull_url)
     end
 
     desc "visit COMMIT", "visit the commit in github"
     def visit(commit)
-      select_remote
       Launchy.open(Url.commit_url(commit))
     end
 
     desc "search COMMIT", "search the commit in github"
     def search(commit)
-      select_remote
       Launchy.open(Url.search_url(commit))
     end
 

--- a/lib/vpr/cli.rb
+++ b/lib/vpr/cli.rb
@@ -64,7 +64,7 @@ module Vpr
     private
 
     def select_remote
-      Configuration.instance.remote = options[:remote].to_sym
+      Configuration.remote = options[:remote].to_sym
     end
   end
 end

--- a/lib/vpr/configuration.rb
+++ b/lib/vpr/configuration.rb
@@ -5,5 +5,22 @@ module Vpr
     include Singleton
 
     attr_accessor :remote
+
+    class << self
+      def method_missing method, *args
+        instance.send(method, *args)
+      rescue NoMethodError
+        super
+      end
+
+      def respond_to_missing?(method_name, include_private = false)
+        ["remote"].include?(method_name) || super
+      end
+    end
+
+    def initialize
+      super
+      @remote = :origin
+    end
   end
 end

--- a/lib/vpr/git_parser.rb
+++ b/lib/vpr/git_parser.rb
@@ -15,15 +15,7 @@ module Vpr
 
     class << self
       def repo_url
-        git = Git.open(Dir.pwd)
-
-        remotes = {}
-        git.remotes.each do |remote|
-          remotes[remote.name.to_sym] = remote.url
-        end
-
-        remote_uri = remotes[Configuration.instance.remote]
-
+        remote_uri = remotes[Configuration.remote]
         matched = remote_uri.match(REGEXP)
 
         File.join("https://#{matched[:host]}", matched[:owner], matched[:repo])
@@ -35,18 +27,17 @@ module Vpr
       end
 
       def host
-        git = Git.open(Dir.pwd)
-
-        remotes = {}
-        git.remotes.each do |remote|
-          remotes[remote.name.to_sym] = remote.url
-        end
-
-        remote_uri = remotes[Configuration.instance.remote]
-
+        remote_uri = remotes[Configuration.remote]
         matched = remote_uri.match(REGEXP)
 
         matched[:host]
+      end
+
+      private
+
+      def remotes
+        git = Git.open(Dir.pwd)
+        git.remotes.map { |remote| [remote.name.to_sym, remote.url] }.to_h
       end
     end
   end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -2,8 +2,6 @@ require "spec_helper"
 require "launchy"
 
 RSpec.describe "CLI" do
-  let(:configuration) { Vpr::Configuration.instance }
-
   describe "home" do
     let(:url) { %r{https://github.com/\w+/vpr} }
 
@@ -15,16 +13,18 @@ RSpec.describe "CLI" do
     context "when user does not specify a remote" do
       it "use :origin by default" do
         expect(Launchy).to receive(:open).with(url)
-        expect(configuration).to receive(:remote).and_return(:origin)
         Vpr::CLI.start(["home"])
       end
     end
 
     context "when user specify a remote" do
+      let(:url) { "https://github.com/EduardoGHdez/vpr" }
+      let(:remotes) { {upstream: "git@github.com:EduardoGHdez/vpr.git"} }
+
       it "open github remote's home page" do
+        allow(Vpr::GitParser).to receive(:remotes).and_return(remotes)
         expect(Launchy).to receive(:open).with(url)
-        expect(configuration).to receive(:remote).and_return(:mine)
-        Vpr::CLI.start(["home", "--remote", "mine"])
+        Vpr::CLI.start(["home", "--remote", "upstream"])
       end
     end
   end
@@ -40,16 +40,18 @@ RSpec.describe "CLI" do
     context "when user does not specify a remote" do
       it "use :origin by default" do
         expect(Launchy).to receive(:open).with(url)
-        expect(configuration).to receive(:remote).and_return(:origin)
         Vpr::CLI.start(["pulls"])
       end
     end
 
     context "when user specify a remote" do
+      let(:url) { "https://github.com/EduardoGHdez/vpr/pulls" }
+      let(:remotes) { {upstream: "git@github.com:EduardoGHdez/vpr.git"} }
+
       it "open github remote's pull request" do
+        allow(Vpr::GitParser).to receive(:remotes).and_return(remotes)
         expect(Launchy).to receive(:open).with(url)
-        expect(configuration).to receive(:remote).and_return(:mine)
-        Vpr::CLI.start(["pulls", "--remote", "mine"])
+        Vpr::CLI.start(["pulls", "--remote", "upstream"])
       end
     end
   end
@@ -65,16 +67,18 @@ RSpec.describe "CLI" do
     context "when user does not specify a remote" do
       it "use :origin by default" do
         expect(Launchy).to receive(:open).with(url)
-        expect(configuration).to receive(:remote).and_return(:origin)
         Vpr::CLI.start(["issues"])
       end
     end
 
     context "when user specify a remote" do
+      let(:url) { "https://github.com/EduardoGHdez/vpr/issues" }
+      let(:remotes) { {upstream: "git@github.com:EduardoGHdez/vpr.git"} }
+
       it "open github remote's issues page" do
+        allow(Vpr::GitParser).to receive(:remotes).and_return(remotes)
         expect(Launchy).to receive(:open).with(url)
-        expect(configuration).to receive(:remote).and_return(:mine)
-        Vpr::CLI.start(["issues", "--remote", "mine"])
+        Vpr::CLI.start(["issues", "--remote", "upstream"])
       end
     end
   end
@@ -90,16 +94,18 @@ RSpec.describe "CLI" do
     context "when user does not specify a remote" do
       it "use :origin by default" do
         expect(Launchy).to receive(:open).with(url)
-        expect(configuration).to receive(:remote).and_return(:origin)
         Vpr::CLI.start(["branches"])
       end
     end
 
     context "when user specify a remote" do
+      let(:url) { "https://github.com/EduardoGHdez/vpr/branches" }
+      let(:remotes) { {upstream: "git@github.com:EduardoGHdez/vpr.git"} }
+
       it "open githube remote's branches page" do
+        allow(Vpr::GitParser).to receive(:remotes).and_return(remotes)
         expect(Launchy).to receive(:open).with(url)
-        expect(configuration).to receive(:remote).and_return(:mine)
-        Vpr::CLI.start(["branches", "--remote", "mine"])
+        Vpr::CLI.start(["branches", "--remote", "upstream"])
       end
     end
   end
@@ -115,16 +121,18 @@ RSpec.describe "CLI" do
     context "when user does not specify a remote" do
       it "use :origin by default" do
         expect(Launchy).to receive(:open).with(url)
-        expect(configuration).to receive(:remote).and_return(:origin)
         Vpr::CLI.start(["branch"])
       end
     end
 
     context "when user specify a remote" do
+      let(:url) { %r{https://github.com/EduardoGHdez/vpr/tree/\w+} }
+      let(:remotes) { {upstream: "git@github.com:EduardoGHdez/vpr.git"} }
+
       it "open github remote's branch page" do
+        allow(Vpr::GitParser).to receive(:remotes).and_return(remotes)
         expect(Launchy).to receive(:open).with(url)
-        expect(configuration).to receive(:remote).and_return(:mine)
-        Vpr::CLI.start(["branch", "--remote", "mine"])
+        Vpr::CLI.start(["branch", "--remote", "upstream"])
       end
     end
   end
@@ -140,16 +148,18 @@ RSpec.describe "CLI" do
     context "when user does not specify a remote" do
       it "use :origin by default" do
         expect(Launchy).to receive(:open).with(url)
-        expect(configuration).to receive(:remote).and_return(:origin)
         Vpr::CLI.start(["pull"])
       end
     end
 
     context "when user specify a remote" do
+      let(:url) { %r{https://github.com/EduardoGHdez/vpr/pull/\w+} }
+      let(:remotes) { {upstream: "git@github.com:EduardoGHdez/vpr.git"} }
+
       it "open github remote's current branch pull request page" do
+        allow(Vpr::GitParser).to receive(:remotes).and_return(remotes)
         expect(Launchy).to receive(:open).with(url)
-        expect(configuration).to receive(:remote).and_return(:mine)
-        Vpr::CLI.start(["pull", "--remote", "mine"])
+        Vpr::CLI.start(["pull", "--remote", "upstream"])
       end
     end
   end
@@ -165,16 +175,18 @@ RSpec.describe "CLI" do
     context "when user does not specify a remote" do
       it "use :origin by default" do
         expect(Launchy).to receive(:open).with(url)
-        expect(configuration).to receive(:remote).twice.and_return(:origin)
         Vpr::CLI.start(["visit", "123"])
       end
     end
 
     context "when user specify a remote" do
+      let(:url) { %r{https://github.com/EduardoGHdez/vpr/commit/123} }
+      let(:remotes) { {upstream: "git@github.com:EduardoGHdez/vpr.git"} }
+
       it "open initial remote's commit github page" do
+        allow(Vpr::GitParser).to receive(:remotes).and_return(remotes)
         expect(Launchy).to receive(:open).with(url)
-        expect(configuration).to receive(:remote).twice.and_return(:mine)
-        Vpr::CLI.start(["visit", "123", "--remote", "mine"])
+        Vpr::CLI.start(["visit", "123", "--remote", "upstream"])
       end
     end
   end
@@ -190,16 +202,18 @@ RSpec.describe "CLI" do
     context "when user does not specify a remote" do
       it "use :origin by default" do
         expect(Launchy).to receive(:open).with(url)
-        expect(configuration).to receive(:remote).and_return(:origin)
         Vpr::CLI.start(["search", "123"])
       end
     end
 
     context "when user specify a remote" do
+      let(:url) { %r{https://github.com/EduardoGHdez/vpr/search\?q=123} }
+      let(:remotes) { {upstream: "git@github.com:EduardoGHdez/vpr.git"} }
+
       it "open initial remote's commit github search page" do
+        allow(Vpr::GitParser).to receive(:remotes).and_return(remotes)
         expect(Launchy).to receive(:open).with(url)
-        expect(configuration).to receive(:remote).and_return(:mine)
-        Vpr::CLI.start(["search", "123", "--remote", "mine"])
+        Vpr::CLI.start(["search", "123", "--remote", "upstream"])
       end
     end
   end

--- a/spec/git_parser_spec.rb
+++ b/spec/git_parser_spec.rb
@@ -6,6 +6,17 @@ RSpec.describe Vpr::GitParser do
       repo_url = %r{https://github.com/\w+/vpr}
       expect(described_class.repo_url).to match(repo_url)
     end
+
+    context "when is using the remote flag" do
+      let(:remotes) { {upstream: "git@github.com:EduardoGHdez/vpr.git"} }
+
+      it "returns the proper repo url" do
+        allow(Vpr::Configuration).to receive(:remote).and_return(:upstream)
+        allow(described_class).to receive(:remotes).and_return(remotes)
+        repo_url = %r{https://github.com/\w+/vpr}
+        expect(described_class.repo_url).to match(repo_url)
+      end
+    end
   end
 
   describe "current_branch" do


### PR DESCRIPTION
Well, before, the specs depended on the existence of an ideal env to pass.

This adds a refactor over the `GitParser` class, which let us improve our mocking for tests and be independent of the env were the tests run.