### PR TITLE
Allow to use vpr even if you are not in the root directory

### DIFF
--- a/lib/vpr/git_parser.rb
+++ b/lib/vpr/git_parser.rb
@@ -22,7 +22,7 @@ module Vpr
       end
 
       def current_branch
-        git = Git.open(Dir.pwd)
+        git = Git.open(git_dir)
         git.current_branch
       end
 
@@ -36,8 +36,21 @@ module Vpr
       private
 
       def remotes
-        git = Git.open(Dir.pwd)
+        git = Git.open(git_dir)
         git.remotes.map { |remote| [remote.name.to_sym, remote.url] }.to_h
+      end
+
+      def git_dir
+        dir = Dir.pwd
+
+        loop do
+          return dir if File.directory?(File.join(dir, ".git"))
+
+          parent = File.dirname(dir)
+          return dir if parent == dir # we're at the root
+
+          dir = parent
+        end
       end
     end
   end

--- a/spec/git_parser_spec.rb
+++ b/spec/git_parser_spec.rb
@@ -17,6 +17,29 @@ RSpec.describe Vpr::GitParser do
         expect(described_class.repo_url).to match(repo_url)
       end
     end
+
+    context "when in a sub folder of the repository" do
+      around do |example|
+        Dir.chdir("lib") { example.run }
+      end
+
+      it "returns the repo url" do
+        repo_url = %r{https://github.com/\w+/vpr}
+        expect(described_class.repo_url).to match(repo_url)
+      end
+    end
+
+    context "when in a folder outside of a git repository" do
+      around do |example|
+        Dir.chdir(Dir.tmpdir) { example.run }
+      end
+
+      it "raises an error" do
+        # TODO: replace with a human readable error message and a non-zero exit
+        # code
+        expect { described_class.repo_url }.to raise_error(ArgumentError)
+      end
+    end
   end
 
   describe "current_branch" do


### PR DESCRIPTION
Before executing git related commands, vpr will explicitly look for the `.git` directory in the current directory and each of it's parent, stopping at the earliest match. This way, similar to the git command line tools, vpr may be used in sub folders.

If vpr cannot find a `.git` directory in any of the parents, then it falls back to using the current directory.