### PR TITLE
Add standardrb checks to default rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,11 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 require "github_changelog_generator/task"
+require "standard/rake"
 
 RSpec::Core::RakeTask.new(:spec)
 
-task default: :spec
+task default: [:standard, :spec]
 
 GitHubChangelogGenerator::RakeTask.new :changelog do |config|
   config.user = "JuanCrg90"


### PR DESCRIPTION
Since standardrb is part of ci, it should also be part of the default rake task, so that new developers will be immediately aware of this build step.