### PR TITLE
Fix vpr --version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    vpr (2.0.0)
+    vpr (2.0.1)
       git (~> 1.5)
       launchy (~> 2.4)
       thor (~> 0.20)

--- a/lib/vpr.rb
+++ b/lib/vpr.rb
@@ -1,8 +1,8 @@
 #:nodoc:
 module Vpr
+  autoload :VERSION, "vpr/version"
   autoload :Configuration, "vpr/configuration"
   autoload :GitParser, "vpr/git_parser"
   autoload :Url, "vpr/url"
   autoload :CLI, "vpr/cli"
-  autoload :VERSION, "vpr/version"
 end

--- a/lib/vpr/cli.rb
+++ b/lib/vpr/cli.rb
@@ -2,6 +2,7 @@ require "thor"
 require "launchy"
 require "vpr/url"
 require "vpr/configuration"
+require "vpr/version"
 
 module Vpr
   class CLI < Thor
@@ -55,7 +56,7 @@ module Vpr
 
     desc "version", "show the gem version"
     def version
-      Vpr::VERSION
+      puts Vpr::VERSION
     end
 
     private

--- a/lib/vpr/version.rb
+++ b/lib/vpr/version.rb
@@ -1,3 +1,3 @@
 module Vpr
-  VERSION = "2.0.0"
+  VERSION = "2.0.1"
 end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -220,11 +220,11 @@ RSpec.describe "CLI" do
 
   describe "version" do
     it "shows gem version with double dash" do
-      expect(Vpr::CLI.start(["--version"])).to match("2.0.0")
+      expect { Vpr::CLI.start(["--version"]) }.to output("2.0.1\n").to_stdout
     end
 
     it "shows gem version without double dash" do
-      expect(Vpr::CLI.start(["version"])).to match("2.0.0")
+      expect { Vpr::CLI.start(["version"]) }.to output("2.0.1\n").to_stdout
     end
   end
 end


### PR DESCRIPTION
Autoload is not loading the VERSION constant. this adds an explicit
require and update the tests for the vpr --version