### PR TITLE
Separate each git service in its own class

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    vpr (2.0.1)
+    vpr (2.1.0)
       git (~> 1.5)
       launchy (~> 2.4)
       thor (~> 0.20)

--- a/lib/vpr.rb
+++ b/lib/vpr.rb
@@ -5,4 +5,5 @@ module Vpr
   autoload :GitParser, "vpr/git_parser"
   autoload :Url, "vpr/url"
   autoload :CLI, "vpr/cli"
+  autoload :Services, "vpr/services"
 end

--- a/lib/vpr/cli.rb
+++ b/lib/vpr/cli.rb
@@ -9,6 +9,7 @@ module Vpr
     def initialize(args = [], local_options = {}, config = {})
       super
       select_remote
+      @url = Url.new
     end
 
     map "--version" => :version
@@ -16,42 +17,42 @@ module Vpr
 
     desc "home", "visit the project page in github"
     def home
-      Launchy.open(Url.home_url)
+      Launchy.open(url.home_url)
     end
 
     desc "pulls", "visit the project pull requests page in github"
     def pulls
-      Launchy.open(Url.pulls_url)
+      Launchy.open(url.pulls_url)
     end
 
     desc "issues", "visit the project issues page in github"
     def issues
-      Launchy.open(Url.issues_url)
+      Launchy.open(url.issues_url)
     end
 
     desc "branches", "visit the project branches page in github"
     def branches
-      Launchy.open(Url.branches_url)
+      Launchy.open(url.branches_url)
     end
 
     desc "branch", "visit the current branch in github"
     def branch
-      Launchy.open(Url.branch_url)
+      Launchy.open(url.branch_url)
     end
 
     desc "pull", "visit the pull request for the current branch (if exist) in github"
     def pull
-      Launchy.open(Url.pull_url)
+      Launchy.open(url.pull_url)
     end
 
     desc "visit COMMIT", "visit the commit in github"
     def visit(commit)
-      Launchy.open(Url.commit_url(commit))
+      Launchy.open(url.commit_url(commit))
     end
 
     desc "search COMMIT", "search the commit in github"
     def search(commit)
-      Launchy.open(Url.search_url(commit))
+      Launchy.open(url.search_url(commit))
     end
 
     desc "version", "show the gem version"
@@ -64,5 +65,7 @@ module Vpr
     def select_remote
       Configuration.remote = options[:remote].to_sym
     end
+
+    attr_reader :url
   end
 end

--- a/lib/vpr/services.rb
+++ b/lib/vpr/services.rb
@@ -1,5 +1,6 @@
 module Vpr
   module Services
     autoload :GitHub, "vpr/services/github"
+    autoload :Bitbucket, "vpr/services/bitbucket"
   end
 end

--- a/lib/vpr/services.rb
+++ b/lib/vpr/services.rb
@@ -1,0 +1,5 @@
+module Vpr
+  module Services
+    autoload :GitHub, "vpr/services/github"
+  end
+end

--- a/lib/vpr/services/bitbucket.rb
+++ b/lib/vpr/services/bitbucket.rb
@@ -1,0 +1,39 @@
+require "vpr/git_parser"
+
+module Vpr
+  module Services
+    class Bitbucket
+      def self.home_url
+        GitParser.repo_url
+      end
+
+      def self.pulls_url
+        "#{GitParser.repo_url}/pull-requests"
+      end
+
+      def self.issues_url
+        "#{GitParser.repo_url}/issues"
+      end
+
+      def self.branches_url
+        "#{GitParser.repo_url}/branches"
+      end
+
+      def self.branch_url
+        "#{GitParser.repo_url}/branch/#{GitParser.current_branch}"
+      end
+
+      def self.pull_url
+        "#{GitParser.repo_url}/pull-requests/new?source=#{GitParser.current_branch}"
+      end
+
+      def self.commit_url(commit)
+        "#{GitParser.repo_url}/commits/#{commit}"
+      end
+
+      def self.search_url(commit)
+        "#{GitParser.repo_url}/commits/all?search=#{commit}"
+      end
+    end
+  end
+end

--- a/lib/vpr/services/github.rb
+++ b/lib/vpr/services/github.rb
@@ -1,0 +1,39 @@
+require "vpr/git_parser"
+
+module Vpr
+  module Services
+    class GitHub
+      def self.home_url
+        GitParser.repo_url
+      end
+
+      def self.pulls_url
+        "#{GitParser.repo_url}/pulls"
+      end
+
+      def self.issues_url
+        "#{GitParser.repo_url}/issues"
+      end
+
+      def self.branches_url
+        "#{GitParser.repo_url}/branches"
+      end
+
+      def self.branch_url
+        "#{GitParser.repo_url}/tree/#{GitParser.current_branch}"
+      end
+
+      def self.pull_url
+        "#{GitParser.repo_url}/pull/#{GitParser.current_branch}"
+      end
+
+      def self.commit_url(commit)
+        "#{GitParser.repo_url}/commit/#{commit}"
+      end
+
+      def self.search_url(commit)
+        "#{GitParser.repo_url}/search?q=#{commit}"
+      end
+    end
+  end
+end

--- a/lib/vpr/url.rb
+++ b/lib/vpr/url.rb
@@ -1,60 +1,53 @@
 require "vpr/git_parser"
+require "vpr/services"
 
 module Vpr
   class Url
-    def self.home_url
-      GitParser.repo_url
+    def initialize
+      @service = services[GitParser.host.to_sym]
     end
 
-    def self.pulls_url
-      path = {
-        'github.com': "pulls",
-        'bitbucket.org': "pull-requests",
+    def home_url
+      service.home_url
+    end
+
+    def pulls_url
+      service.pulls_url
+    end
+
+    def issues_url
+      service.issues_url
+    end
+
+    def branches_url
+      service.branches_url
+    end
+
+    def branch_url
+      service.branch_url
+    end
+
+    def pull_url
+      service.pull_url
+    end
+
+    def commit_url(commit)
+      service.commit_url(commit)
+    end
+
+    def search_url(commit)
+      service.search_url(commit)
+    end
+
+    private
+
+    def services
+      {
+        'github.com': Vpr::Services::GitHub,
+        'bitbucket.org': Vpr::Services::Bitbucket,
       }
-
-      "#{GitParser.repo_url}/#{path[GitParser.host.to_sym]}"
     end
 
-    def self.issues_url
-      "#{GitParser.repo_url}/issues"
-    end
-
-    def self.branches_url
-      "#{GitParser.repo_url}/branches"
-    end
-
-    def self.branch_url
-      path = {
-        'github.com': "tree",
-        'bitbucket.org': "branch",
-      }
-      "#{GitParser.repo_url}/#{path[GitParser.host.to_sym]}/#{GitParser.current_branch}"
-    end
-
-    def self.pull_url
-      path = {
-        'github.com': "pull/#{GitParser.current_branch}",
-        'bitbucket.org': "pull-requests/new?source=#{GitParser.current_branch}",
-      }
-
-      "#{GitParser.repo_url}/#{path[GitParser.host.to_sym]}"
-    end
-
-    def self.commit_url(commit)
-      path = {
-        'github.com': "commit",
-        'bitbucket.org': "commits",
-      }
-
-      "#{GitParser.repo_url}/#{path[GitParser.host.to_sym]}/#{commit}"
-    end
-
-    def self.search_url(commit)
-      path = {
-        'github.com': "search?q=",
-        'bitbucket.org': "commits/all?search=",
-      }
-      "#{GitParser.repo_url}/#{path[GitParser.host.to_sym]}#{commit}"
-    end
+    attr_reader :service
   end
 end

--- a/lib/vpr/version.rb
+++ b/lib/vpr/version.rb
@@ -1,3 +1,3 @@
 module Vpr
-  VERSION = "2.0.1"
+  VERSION = "2.1.0"
 end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -220,11 +220,11 @@ RSpec.describe "CLI" do
 
   describe "version" do
     it "shows gem version with double dash" do
-      expect { Vpr::CLI.start(["--version"]) }.to output("2.0.1\n").to_stdout
+      expect { Vpr::CLI.start(["--version"]) }.to output("2.1.0\n").to_stdout
     end
 
     it "shows gem version without double dash" do
-      expect { Vpr::CLI.start(["version"]) }.to output("2.0.1\n").to_stdout
+      expect { Vpr::CLI.start(["version"]) }.to output("2.1.0\n").to_stdout
     end
   end
 end

--- a/spec/services/bitbucket_spec.rb
+++ b/spec/services/bitbucket_spec.rb
@@ -1,0 +1,85 @@
+require "spec_helper"
+
+RSpec.describe Vpr::Services::Bitbucket do
+  let(:commit) { "30bd60" }
+
+  describe ".home_url" do
+    subject { described_class.home_url }
+
+    it "returns the project url" do
+      url = %r{https://bitbucket.org/\w+/vpr}
+      expect(Vpr::GitParser).to receive(:repo_url).and_return("https://bitbucket.org/JuanCrg90/vpr")
+      expect(subject).to match(url)
+    end
+  end
+
+  describe ".pulls_url" do
+    subject { described_class.pulls_url }
+
+    it "returns the commit url" do
+      url = %r{https://bitbucket.org/\w+/vpr/pull-requests}
+      expect(Vpr::GitParser).to receive(:repo_url).and_return("https://bitbucket.org/JuanCrg90/vpr")
+      expect(subject).to match(url)
+    end
+  end
+
+  describe ".issues_url" do
+    subject { described_class.issues_url }
+
+    it "returns the  issues url" do
+      url = %r{https://bitbucket.org/\w+/vpr/issues}
+      expect(Vpr::GitParser).to receive(:repo_url).and_return("https://bitbucket.org/JuanCrg90/vpr")
+      expect(subject).to match(url)
+    end
+  end
+
+  describe ".branches_url" do
+    subject { described_class.branches_url }
+
+    it "returns the  issues url" do
+      url = %r{https://bitbucket.org/\w+/vpr/branches}
+      expect(Vpr::GitParser).to receive(:repo_url).and_return("https://bitbucket.org/JuanCrg90/vpr")
+      expect(subject).to match(url)
+    end
+  end
+
+  describe ".branch_url" do
+    subject { described_class.branch_url }
+
+    it "returns the branch url" do
+      url = %r{https://bitbucket.org/\w+/vpr/branch/\w+}
+      expect(Vpr::GitParser).to receive(:repo_url).and_return("https://bitbucket.org/JuanCrg90/vpr")
+      expect(subject).to match(url)
+    end
+  end
+
+  describe ".pull_url" do
+    subject { described_class.pull_url }
+
+    it "returns the pull request" do
+      url = %r{https://bitbucket.org/\w+/vpr/pull-requests/new\?source=\w+}
+      expect(Vpr::GitParser).to receive(:repo_url).and_return("https://bitbucket.org/JuanCrg90/vpr")
+      expect(subject).to match(url)
+    end
+  end
+
+  describe ".commit_url" do
+    subject { described_class.commit_url(commit) }
+
+    it "returns the commit url" do
+      url = %r{https://bitbucket.org/\w+/vpr/commits/30bd60}
+      expect(Vpr::GitParser).to receive(:repo_url).and_return("https://bitbucket.org/JuanCrg90/vpr")
+      expect(subject).to match(url)
+    end
+  end
+
+  describe ".search_url" do
+    subject { described_class.search_url(commit) }
+
+    it "returns the search page url" do
+      url = %r{https://bitbucket.org/\w+/vpr/commits/all\?search=30bd60}
+      expect(Vpr::GitParser).to receive(:repo_url).and_return("https://bitbucket.org/JuanCrg90/vpr")
+      expect(subject).to match(url)
+    end
+  end
+end

--- a/spec/services/github_spec.rb
+++ b/spec/services/github_spec.rb
@@ -1,0 +1,77 @@
+require "spec_helper"
+
+RSpec.describe Vpr::Services::GitHub do
+  let(:commit) { "30bd60" }
+
+  describe ".home_url" do
+    subject { described_class.home_url }
+
+    it "returns the project url" do
+      url = %r{https://github.com/\w+/vpr}
+      expect(subject).to match(url)
+    end
+  end
+
+  describe ".pulls_url" do
+    subject { described_class.pulls_url }
+
+    it "returns the commit url" do
+      url = %r{https://github.com/\w+/vpr/pulls}
+      expect(subject).to match(url)
+    end
+  end
+
+  describe ".issues_url" do
+    subject { described_class.issues_url }
+
+    it "returns the  issues url" do
+      url = %r{https://github.com/\w+/vpr/issues}
+      expect(subject).to match(url)
+    end
+  end
+
+  describe ".branches_url" do
+    subject { described_class.branches_url }
+
+    it "returns the branches url" do
+      url = %r{https://github.com/\w+/vpr/branches}
+      expect(subject).to match(url)
+    end
+  end
+
+  describe ".branch_url" do
+    subject { described_class.branch_url }
+
+    it "returns the branch url" do
+      url = %r{https://github.com/\w+/vpr/tree/\w+}
+      expect(subject).to match(url)
+    end
+  end
+
+  describe ".pull_url" do
+    subject { described_class.pull_url }
+
+    it "returns the current branch pull request url" do
+      url = %r{https://github.com/\w+/vpr/pull/\w+}
+      expect(subject).to match(url)
+    end
+  end
+
+  describe ".commit_url" do
+    subject { described_class.commit_url(commit) }
+
+    it "returns the commit url" do
+      url = %r{https://github.com/\w+/vpr/commit/30bd60}
+      expect(subject).to match(url)
+    end
+  end
+
+  describe ".search_url" do
+    subject { described_class.search_url(commit) }
+
+    it "returns the search page url" do
+      url = %r{https://github.com/\w+/vpr/search\?q=30bd60}
+      expect(subject).to match(url)
+    end
+  end
+end

--- a/spec/url_spec.rb
+++ b/spec/url_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Vpr::Url do
   let(:commit) { "30bd60" }
 
   describe ".home_url" do
-    subject { described_class.home_url }
+    subject { described_class.new.home_url }
 
     it "returns the project url" do
       url = %r{https://github.com/\w+/vpr}
@@ -13,7 +13,7 @@ RSpec.describe Vpr::Url do
   end
 
   describe ".pulls_url" do
-    subject { described_class.pulls_url }
+    subject { described_class.new.pulls_url }
 
     context "when github" do
       it "returns the commit url" do
@@ -33,7 +33,7 @@ RSpec.describe Vpr::Url do
   end
 
   describe ".issues_url" do
-    subject { described_class.issues_url }
+    subject { described_class.new.issues_url }
 
     it "returns the  issues url" do
       url = %r{https://github.com/\w+/vpr/issues}
@@ -41,17 +41,17 @@ RSpec.describe Vpr::Url do
     end
   end
 
-  describe ".issues_url" do
-    subject { described_class.branches_url }
+  describe ".branches" do
+    subject { described_class.new.branches_url }
 
-    it "returns the  issues url" do
+    it "returns the branches url" do
       url = %r{https://github.com/\w+/vpr/branches}
       expect(subject).to match(url)
     end
   end
 
   describe ".branch_url" do
-    subject { described_class.branch_url }
+    subject { described_class.new.branch_url }
 
     context "when github" do
       it "returns the branch url" do
@@ -71,7 +71,7 @@ RSpec.describe Vpr::Url do
   end
 
   describe ".pull_url" do
-    subject { described_class.pull_url }
+    subject { described_class.new.pull_url }
 
     context "when github" do
       it "returns the current branch pull request url" do
@@ -91,7 +91,7 @@ RSpec.describe Vpr::Url do
   end
 
   describe ".commit_url" do
-    subject { described_class.commit_url(commit) }
+    subject { described_class.new.commit_url(commit) }
 
     context "when github" do
       it "returns the commit url" do
@@ -111,7 +111,7 @@ RSpec.describe Vpr::Url do
   end
 
   describe ".search_url" do
-    subject { described_class.search_url(commit) }
+    subject { described_class.new.search_url(commit) }
 
     context "when github" do
       it "returns the search page url" do


### PR DESCRIPTION
We want to handle every service (GitHub, Bitbucket, etc) in an independent class instead of using switch statements in the Url class methods.

This creates two new service classes and refactors the Url class to select the right service when the Url object is created.