### PR TITLE
Add support for number slash branches

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    vpr (2.1.0)
+    vpr (2.2.0)
       git (~> 1.5)
       launchy (~> 2.4)
       thor (~> 0.20)
@@ -90,7 +90,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 2.0)
+  bundler (~> 2.1)
   github_changelog_generator (~> 1.14)
   rake (~> 10.0)
   rspec (~> 3.0)
@@ -99,4 +99,4 @@ DEPENDENCIES
   vpr!
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/lib/vpr/services/github.rb
+++ b/lib/vpr/services/github.rb
@@ -24,7 +24,12 @@ module Vpr
       end
 
       def self.pull_url
-        "#{GitParser.repo_url}/pull/#{GitParser.current_branch}"
+        base_url = "#{GitParser.repo_url}/pull"
+        current_branch = GitParser.current_branch
+
+        base_url.concat("/new") if current_branch.match?(/\d+\/.+/)
+
+        "#{base_url}/#{current_branch}"
       end
 
       def self.commit_url(commit)

--- a/lib/vpr/version.rb
+++ b/lib/vpr/version.rb
@@ -1,3 +1,3 @@
 module Vpr
-  VERSION = "2.1.0"
+  VERSION = "2.2.0"
 end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -220,11 +220,11 @@ RSpec.describe "CLI" do
 
   describe "version" do
     it "shows gem version with double dash" do
-      expect { Vpr::CLI.start(["--version"]) }.to output("2.1.0\n").to_stdout
+      expect { Vpr::CLI.start(["--version"]) }.to output("2.2.0\n").to_stdout
     end
 
     it "shows gem version without double dash" do
-      expect { Vpr::CLI.start(["version"]) }.to output("2.1.0\n").to_stdout
+      expect { Vpr::CLI.start(["version"]) }.to output("2.2.0\n").to_stdout
     end
   end
 end

--- a/spec/services/github_spec.rb
+++ b/spec/services/github_spec.rb
@@ -51,9 +51,24 @@ RSpec.describe Vpr::Services::GitHub do
   describe ".pull_url" do
     subject { described_class.pull_url }
 
-    it "returns the current branch pull request url" do
-      url = %r{https://github.com/\w+/vpr/pull/\w+}
-      expect(subject).to match(url)
+    context "when branch start with a word" do
+      it "returns the current branch pull request url" do
+        branch = "feature/my-feature"
+        expect(Vpr::GitParser).to receive(:current_branch).and_return(branch)
+
+        url = %r{https://github.com/\w+/vpr/pull/\w+}
+        expect(subject).to match(url)
+      end
+    end
+
+    context "when branch start with number slash" do
+      it "returns the new pull request url" do
+        branch = "123/feature"
+        expect(Vpr::GitParser).to receive(:current_branch).and_return(branch)
+
+        url = %r{https://github.com/\w+/vpr/pull/new/\d+/\w+}
+        expect(subject).to match(url)
+      end
     end
   end
 

--- a/vpr.gemspec
+++ b/vpr.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 2.0"
+  spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "github_changelog_generator", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
Branches like `123/feature` are not resolved by `vpr pull` command, this
commit send to the pull/new github page for this kind of branches.