### PR TITLE
Upgrade Git Gem to version 1.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    vpr (2.2.0)
+    vpr (2.2.1)
       git (~> 1.7)
       launchy (~> 2.4)
       thor (~> 0.20)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     vpr (2.2.0)
-      git (~> 1.5)
+      git (~> 1.7)
       launchy (~> 2.4)
       thor (~> 0.20)
 
@@ -24,7 +24,8 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday-http-cache (2.0.0)
       faraday (~> 0.8)
-    git (1.5.0)
+    git (1.7.0)
+      rchardet (~> 1.8)
     github_changelog_generator (1.14.3)
       activesupport
       faraday-http-cache
@@ -49,6 +50,7 @@ GEM
     public_suffix (3.1.1)
     rainbow (3.0.0)
     rake (13.0.1)
+    rchardet (1.8.0)
     retriable (2.1.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)

--- a/lib/vpr/version.rb
+++ b/lib/vpr/version.rb
@@ -1,3 +1,3 @@
 module Vpr
-  VERSION = "2.2.0"
+  VERSION = "2.2.1"
 end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -220,11 +220,11 @@ RSpec.describe "CLI" do
 
   describe "version" do
     it "shows gem version with double dash" do
-      expect { Vpr::CLI.start(["--version"]) }.to output("2.2.0\n").to_stdout
+      expect { Vpr::CLI.start(["--version"]) }.to output("#{Vpr::VERSION}\n").to_stdout
     end
 
     it "shows gem version without double dash" do
-      expect { Vpr::CLI.start(["version"]) }.to output("2.2.0\n").to_stdout
+      expect { Vpr::CLI.start(["version"]) }.to output("#{Vpr::VERSION}\n").to_stdout
     end
   end
 end

--- a/vpr.gemspec
+++ b/vpr.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec_junit_formatter", "~> 0.4"
   spec.add_development_dependency "standard"
 
-  spec.add_runtime_dependency "git", "~> 1.5"
+  spec.add_runtime_dependency "git", "~> 1.7"
   spec.add_runtime_dependency "launchy", "~> 2.4"
   spec.add_runtime_dependency "thor", "~> 0.20"
 end


### PR DESCRIPTION
Ruby 2.7 has some deprecation warnings for keyword arguments.
This upgrades the git gem to version that fix this warnings.

see https://github.com/ruby-git/ruby-git/commit/af4902b3338242d2a0948dac7484751a8e102a00