### PR TITLE
Error message when there is no repository

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    vpr (2.3.0)
+    vpr (2.3.1)
       git (~> 1.7)
       launchy (~> 2.4)
       thor (~> 0.20)

--- a/lib/vpr/git_parser.rb
+++ b/lib/vpr/git_parser.rb
@@ -47,7 +47,9 @@ module Vpr
           return dir if File.directory?(File.join(dir, ".git"))
 
           parent = File.dirname(dir)
-          return dir if parent == dir # we're at the root
+
+          # NOTE: Raising an error because at this point it is at the root dir
+          raise Thor::Error.new("There is no repository in current directory") if parent == dir
 
           dir = parent
         end

--- a/lib/vpr/version.rb
+++ b/lib/vpr/version.rb
@@ -1,3 +1,3 @@
 module Vpr
-  VERSION = "2.3.0"
+  VERSION = "2.3.1"
 end

--- a/spec/git_parser_spec.rb
+++ b/spec/git_parser_spec.rb
@@ -35,9 +35,7 @@ RSpec.describe Vpr::GitParser do
       end
 
       it "raises an error" do
-        # TODO: replace with a human readable error message and a non-zero exit
-        # code
-        expect { described_class.repo_url }.to raise_error(ArgumentError)
+        expect { described_class.repo_url }.to raise_error Thor::Error
       end
     end
   end


### PR DESCRIPTION
Rather than showing an `ArgumentError` when there is no repository in the
current dir, it shows a human-readable error-messages

| Before |
| - |
| ![image](https://user-images.githubusercontent.com/39539196/97121654-99e25180-16e5-11eb-84b5-548f22827e8e.png) |

| After |
| - |
| ![image](https://user-images.githubusercontent.com/39539196/97121658-aa92c780-16e5-11eb-87ad-6fe932c87a69.png) |
