### PR TITLE
Ability to specify branch in pull command

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    vpr (2.3.1)
+    vpr (2.3.2)
       git (~> 1.7)
       launchy (~> 2.4)
       thor (~> 0.20)

--- a/lib/vpr/cli.rb
+++ b/lib/vpr/cli.rb
@@ -40,9 +40,15 @@ module Vpr
       Launchy.open(url.branch_url)
     end
 
-    desc "pull", "visit the pull request for the current branch (if exist) in github"
-    def pull
-      Launchy.open(url.pull_url)
+    desc "pull [BRANCH]", "visit the pull request for the BRANCH in any of the supported hosts"
+    long_desc <<-DESC
+      It visits the pull request for the BRANCH in any of the supported hosts
+
+      Since the branch is an optional arg, it uses the current branch by default
+    DESC
+
+    def pull(branch = nil)
+      Launchy.open(url.pull_url(branch))
     end
 
     desc "visit COMMIT", "visit the commit in github"

--- a/lib/vpr/services/bitbucket.rb
+++ b/lib/vpr/services/bitbucket.rb
@@ -23,8 +23,9 @@ module Vpr
         "#{GitParser.repo_url}/branch/#{GitParser.current_branch}"
       end
 
-      def self.pull_url
-        "#{GitParser.repo_url}/pull-requests/new?source=#{GitParser.current_branch}"
+      def self.pull_url(branch = nil)
+        branch ||= GitParser.current_branch
+        "#{GitParser.repo_url}/pull-requests/new?source=#{branch}"
       end
 
       def self.commit_url(commit)

--- a/lib/vpr/services/github.rb
+++ b/lib/vpr/services/github.rb
@@ -23,13 +23,13 @@ module Vpr
         "#{GitParser.repo_url}/tree/#{GitParser.current_branch}"
       end
 
-      def self.pull_url
+      def self.pull_url(branch = nil)
+        branch ||= GitParser.current_branch
         base_url = "#{GitParser.repo_url}/pull"
-        current_branch = GitParser.current_branch
 
-        base_url.concat("/new") if current_branch.match?(/\d+\/.+/)
+        base_url.concat("/new") if branch.match?(/\d+\/.+/)
 
-        "#{base_url}/#{current_branch}"
+        "#{base_url}/#{branch}"
       end
 
       def self.commit_url(commit)

--- a/lib/vpr/services/gitlab.rb
+++ b/lib/vpr/services/gitlab.rb
@@ -23,8 +23,9 @@ module Vpr
         "#{GitParser.repo_url}/-/tree/#{GitParser.current_branch}"
       end
 
-      def self.pull_url
-        "#{GitParser.repo_url}/-/merge_requests/#{GitParser.current_branch}"
+      def self.pull_url(branch = nil)
+        branch ||= GitParser.current_branch
+        "#{GitParser.repo_url}/-/merge_requests/#{branch}"
       end
 
       def self.commit_url(commit)

--- a/lib/vpr/url.rb
+++ b/lib/vpr/url.rb
@@ -27,8 +27,8 @@ module Vpr
       service.branch_url
     end
 
-    def pull_url
-      service.pull_url
+    def pull_url(branch = nil)
+      service.pull_url(branch)
     end
 
     def commit_url(commit)

--- a/lib/vpr/version.rb
+++ b/lib/vpr/version.rb
@@ -1,3 +1,3 @@
 module Vpr
-  VERSION = "2.3.1"
+  VERSION = "2.3.2"
 end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -162,6 +162,24 @@ RSpec.describe "CLI" do
         Vpr::CLI.start(["pull", "--remote", "upstream"])
       end
     end
+
+    context "when user specify a branch" do
+      it "open github branch's pull request" do
+        expected_url = %r{https://github.com/\w+/vpr/pull/foo}
+
+        expect(Launchy).to receive(:open).with(expected_url)
+        Vpr::CLI.start(["pull", "foo"])
+      end
+    end
+
+    context "when user does not specify a branch" do
+      before { allow(Vpr::GitParser).to receive(:current_branch) { "bar" } }
+      it "opens github current branch's pull request" do
+        expected_url = %r{https://github.com/\w+/vpr/pull/bar}
+        expect(Launchy).to receive(:open).with(expected_url)
+        Vpr::CLI.start(["pull"])
+      end
+    end
   end
 
   describe "visit" do

--- a/spec/services/bitbucket_spec.rb
+++ b/spec/services/bitbucket_spec.rb
@@ -61,6 +61,26 @@ RSpec.describe Vpr::Services::Bitbucket do
       expect(Vpr::GitParser).to receive(:repo_url).and_return("https://bitbucket.org/JuanCrg90/vpr")
       expect(subject).to match(url)
     end
+
+    context "when no branch is passed" do
+      before { allow(Vpr::GitParser).to receive(:current_branch).and_return "foo-branch" }
+
+      it "uses the current branch for generating the pull request url" do
+        url = %r{https://bitbucket.org/\w+/vpr/pull-requests/new\?source=foo-branch}
+        expect(Vpr::GitParser).to receive(:repo_url).and_return("https://bitbucket.org/JuanCrg90/vpr")
+        expect(subject).to match(url)
+      end
+    end
+
+    context "whend it branch is passed" do
+      subject { described_class.pull_url("awesome-branch") }
+
+      it "uses it for generating the pull request url" do
+        url = %r{https://bitbucket.org/\w+/vpr/pull-requests/new\?source=awesome-branch}
+        expect(Vpr::GitParser).to receive(:repo_url).and_return("https://bitbucket.org/JuanCrg90/vpr")
+        expect(subject).to match(url)
+      end
+    end
   end
 
   describe ".commit_url" do

--- a/spec/services/github_spec.rb
+++ b/spec/services/github_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Vpr::Services::GitHub do
   describe ".pull_url" do
     subject { described_class.pull_url }
 
-    context "when branch start with a word" do
+    context "when current branch start with a word" do
       it "returns the current branch pull request url" do
         branch = "feature/my-feature"
         expect(Vpr::GitParser).to receive(:current_branch).and_return(branch)
@@ -61,12 +61,31 @@ RSpec.describe Vpr::Services::GitHub do
       end
     end
 
-    context "when branch start with number slash" do
+    context "when current branch start with number slash" do
       it "returns the new pull request url" do
         branch = "123/feature"
         expect(Vpr::GitParser).to receive(:current_branch).and_return(branch)
 
         url = %r{https://github.com/\w+/vpr/pull/new/\d+/.+}
+        expect(subject).to match(url)
+      end
+    end
+
+    context "when no branch is passed" do
+      before { allow(Vpr::GitParser).to receive(:current_branch).and_return "foo-branch" }
+      it "uses the current branch for generating the pull request url" do
+        url = %r{https://github.com/\w+/vpr/pull/foo-branch}
+        expect(Vpr::GitParser).to receive(:repo_url).and_return("https://github.com/JuanCrg90/vpr")
+        expect(subject).to match(url)
+      end
+    end
+
+    context "when branch is passed" do
+      subject { described_class.pull_url("awesome-branch") }
+
+      it "uses it for generating the pull request url" do
+        url = %r{https://github.com/\w+/vpr/pull/awesome-branch}
+        expect(Vpr::GitParser).to receive(:repo_url).and_return("https://github.com/JuanCrg90/vpr")
         expect(subject).to match(url)
       end
     end

--- a/spec/services/gitlab_spec.rb
+++ b/spec/services/gitlab_spec.rb
@@ -61,6 +61,26 @@ RSpec.describe Vpr::Services::GitLab do
       expect(Vpr::GitParser).to receive(:repo_url).and_return("https://gitlab.com/JuanCrg90/vpr")
       expect(subject).to match(url)
     end
+
+    context "when no branch is passed" do
+      before { allow(Vpr::GitParser).to receive(:current_branch).and_return "foo-branch" }
+
+      it "uses the current branch for generating the pull request url" do
+        url = %r{https://gitlab.com/\w+/vpr/-/merge_requests/foo-branch}
+        expect(Vpr::GitParser).to receive(:repo_url).and_return("https://gitlab.com/JuanCrg90/vpr")
+        expect(subject).to match(url)
+      end
+    end
+
+    context "whend it branch is passed" do
+      subject { described_class.pull_url("awesome-branch") }
+
+      it "uses it for generating the pull request url" do
+        url = %r{https://gitlab.com/\w+/vpr/-/merge_requests/awesome-branch}
+        expect(Vpr::GitParser).to receive(:repo_url).and_return("https://gitlab.com/JuanCrg90/vpr")
+        expect(subject).to match(url)
+      end
+    end
   end
 
   describe ".commit_url" do

--- a/spec/url_spec.rb
+++ b/spec/url_spec.rb
@@ -88,6 +88,15 @@ RSpec.describe Vpr::Url do
         expect(subject).to match(url)
       end
     end
+
+    context "when gitlab" do
+      it "returns the merge request" do
+        url = %r{https://gitlab.com/\w+/vpr/-/merge_requests/.+}
+        expect(Vpr::GitParser).to receive(:host).and_return("gitlab.com")
+        expect(Vpr::GitParser).to receive(:repo_url).and_return("https://gitlab.com/JuanCrg90/vpr")
+        expect(subject).to match(url)
+      end
+    end
   end
 
   describe ".commit_url" do


### PR DESCRIPTION
This adds the ability to specify what branch we want to use for generating the pull-request URL in all supported services 