### PR TITLE
Bump git from 1.9.1 to 1.12.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,7 +62,8 @@ GEM
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
     fiber-local (1.0.0)
-    git (1.9.1)
+    git (1.12.0)
+      addressable (~> 2.8)
       rchardet (~> 1.8)
     github_changelog_generator (1.16.4)
       activesupport


### PR DESCRIPTION
Fix vulneravility with CVE: CVE-2022-25648

See: https://github.com/ruby-git/ruby-git/issues/568