### PR TITLE
Fix Repo extraction in regex

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'

--- a/lib/vpr/git_parser.rb
+++ b/lib/vpr/git_parser.rb
@@ -30,6 +30,15 @@ module Vpr
         remote_uri = remotes[Configuration.remote]
         matched = remote_uri.match(GIT_REPO_URL_REGEX)
 
+        puts "------------------"
+        puts "remotes: #{remotes}"
+        puts "remote: #{Configuration.remote}"
+        puts "remote_uri: #{remote_uri}"
+        puts "regex: #{GIT_REPO_URL_REGEX}"
+        puts remote_uri.match(GIT_REPO_URL_REGEX)
+        puts "matched: #{matched}"
+        puts "------------------"
+
         matched[:host]
       end
 

--- a/lib/vpr/git_parser.rb
+++ b/lib/vpr/git_parser.rb
@@ -3,20 +3,20 @@ require "vpr/configuration"
 
 module Vpr
   class GitParser
-    REGEXP = %r{
+    GIT_REPO_URL_REGEX = %r{
     (?<protocol>(http://|https://|git://|ssh://))*
       (?<username>[^@]+@)*
       (?<host>[^/]+)
     [/:]
     (?<owner>[^/]+)
     /
-    (?<repo>[^\/]+[^(.git)])
+    (?<repo>[^\/]+)\.git
     }x.freeze
 
     class << self
       def repo_url
         remote_uri = remotes[Configuration.remote]
-        matched = remote_uri.match(REGEXP)
+        matched = remote_uri.match(GIT_REPO_URL_REGEX)
 
         File.join("https://#{matched[:host]}", matched[:owner], matched[:repo])
       end
@@ -28,7 +28,7 @@ module Vpr
 
       def host
         remote_uri = remotes[Configuration.remote]
-        matched = remote_uri.match(REGEXP)
+        matched = remote_uri.match(GIT_REPO_URL_REGEX)
 
         matched[:host]
       end

--- a/spec/git_parser_spec.rb
+++ b/spec/git_parser_spec.rb
@@ -1,6 +1,37 @@
 require "spec_helper"
 
 RSpec.describe Vpr::GitParser do
+  describe "GIT_REPO_URL_REGEX maches as expected" do
+    context "URI matches correctly" do
+      it "it matches vpr as repo name" do
+        remote_uri = "git@github.com:JuanCrg90/vpr.git"
+
+        matched = remote_uri.match(described_class::GIT_REPO_URL_REGEX)
+        expect(matched[:host]).to eq("github.com")
+        expect(matched[:owner]).to eq("JuanCrg90")
+        expect(matched[:repo]).to eq("vpr")
+      end
+
+      it "matches compi as repo name" do
+        remote_uri = "git@github.com:JuanCrg90/compi.git"
+
+        matched = remote_uri.match(described_class::GIT_REPO_URL_REGEX)
+        expect(matched[:host]).to eq("github.com")
+        expect(matched[:owner]).to eq("JuanCrg90")
+        expect(matched[:repo]).to eq("compi")
+      end
+
+      it "matches app_checkout as repo name" do
+        remote_uri = "git@github.com:JuanCrg90/app_checkout.git"
+
+        matched = remote_uri.match(described_class::GIT_REPO_URL_REGEX)
+        expect(matched[:host]).to eq("github.com")
+        expect(matched[:owner]).to eq("JuanCrg90")
+        expect(matched[:repo]).to eq("app_checkout")
+      end
+    end
+  end
+
   describe ".repo_url" do
     it "returns the repo url" do
       repo_url = %r{https://github.com/\w+/vpr}


### PR DESCRIPTION
I noticed that repositories that ends en i or t failed, this updates the regex to support the expected values and adds some tests, we could consider to extract the regex to its own module for isolation but I think its too much considering is only used here for remote parsing.