### PR TITLE
Improve CI action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,17 @@
 name: CI
-on: [push, pull_request]
+on:
+   pull_request:
+     branches: [ master ]
+   push:
+     branches: [ master ]
 jobs:
   test:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-        ruby: ['2.7', '3.0', '3.1', head]
+        ruby: ['2.7', '3.0', '3.1', '3.2', head]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
This change includes ruby 3.2 in the matrix, removes macos from the os matrix and ensures run the action in the right events.